### PR TITLE
Master 10.0.2

### DIFF
--- a/MediaBrowser.Controller/Library/TVUtils.cs
+++ b/MediaBrowser.Controller/Library/TVUtils.cs
@@ -11,7 +11,7 @@ namespace MediaBrowser.Controller.Library
         /// <summary>
         /// The TVDB API key
         /// </summary>
-        public static readonly string TvdbApiKey = "B89CE93890E9419B";
+        public static readonly string TvdbApiKey = "OG4V3YJ3FAP7FP2K";
         public static readonly string TvdbBaseUrl = "https://www.thetvdb.com/";
         /// <summary>
         /// The banner URL

--- a/MediaBrowser.Controller/Providers/RemoteSearchQuery.cs
+++ b/MediaBrowser.Controller/Providers/RemoteSearchQuery.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace MediaBrowser.Controller.Providers
 {
     public class RemoteSearchQuery<T>
@@ -5,7 +7,7 @@ namespace MediaBrowser.Controller.Providers
     {
         public T SearchInfo { get; set; }
 
-        public string ItemId { get; set; }
+        public Guid ItemId { get; set; }
 
         /// <summary>
         /// If set will only search within the given provider

--- a/MediaBrowser.MediaEncoding/Subtitles/OpenSubtitleDownloader.cs
+++ b/MediaBrowser.MediaEncoding/Subtitles/OpenSubtitleDownloader.cs
@@ -46,7 +46,7 @@ namespace MediaBrowser.MediaEncoding.Subtitles
             _config.NamedConfigurationUpdating += _config_NamedConfigurationUpdating;
 
             Utilities.HttpClient = httpClient;
-            OpenSubtitles.SetUserAgent("mediabrowser.tv");
+            OpenSubtitles.SetUserAgent("jellyfin");
         }
 
         private const string PasswordHashPrefix = "h:";

--- a/MediaBrowser.Providers/Manager/ProviderManager.cs
+++ b/MediaBrowser.Providers/Manager/ProviderManager.cs
@@ -156,7 +156,7 @@ namespace MediaBrowser.Providers.Manager
 
             }).ConfigureAwait(false))
             {
-                // Workaround for tvheadend channel icons	
+                // Workaround for tvheadend channel icons
                 // TODO: Isolate this hack into the tvh plugin
                 if (string.IsNullOrEmpty(response.ContentType))
                 {

--- a/MediaBrowser.Providers/Movies/FanartMovieImageProvider.cs
+++ b/MediaBrowser.Providers/Movies/FanartMovieImageProvider.cs
@@ -37,7 +37,6 @@ namespace MediaBrowser.Providers.Movies
         private readonly IJsonSerializer _json;
 
         private const string FanArtBaseUrl = "https://webservice.fanart.tv/v3/movies/{1}?api_key={0}";
-        // &client_key=52c813aa7b8c8b3bb87f4797532a2f8c
 
         internal static FanartMovieImageProvider Current;
 

--- a/MediaBrowser.Providers/Movies/MovieDbProvider.cs
+++ b/MediaBrowser.Providers/Movies/MovieDbProvider.cs
@@ -168,7 +168,7 @@ namespace MediaBrowser.Providers.Movies
         private const string TmdbConfigUrl = BaseMovieDbUrl + "3/configuration?api_key={0}";
         private const string GetMovieInfo3 = BaseMovieDbUrl + @"3/movie/{0}?api_key={1}&append_to_response=casts,releases,images,keywords,trailers";
 
-        internal static string ApiKey = "f6bd687ffa63cd282b6ff2c6877f2669";
+        internal static string ApiKey = "4219e299c89411838049ab0dab19ebd5";
         internal static string AcceptHeader = "application/json,image/*";
 
         /// <summary>

--- a/MediaBrowser.Providers/Movies/MovieDbSearch.cs
+++ b/MediaBrowser.Providers/Movies/MovieDbSearch.cs
@@ -20,7 +20,7 @@ namespace MediaBrowser.Providers.Movies
         private static readonly CultureInfo EnUs = new CultureInfo("en-US");
         private const string Search3 = MovieDbProvider.BaseMovieDbUrl + @"3/search/{3}?api_key={1}&query={0}&language={2}";
 
-        internal static string ApiKey = "f6bd687ffa63cd282b6ff2c6877f2669";
+        internal static string ApiKey = "4219e299c89411838049ab0dab19ebd5";
         internal static string AcceptHeader = "application/json,image/*";
 
         private readonly ILogger _logger;

--- a/MediaBrowser.Providers/Music/AudioDbArtistProvider.cs
+++ b/MediaBrowser.Providers/Music/AudioDbArtistProvider.cs
@@ -27,7 +27,7 @@ namespace MediaBrowser.Providers.Music
 
         public static AudioDbArtistProvider Current;
 
-        private const string ApiKey = "49jhsf8248yfahka89724011";
+        private const string ApiKey = "195003";
         public const string BaseUrl = "https://www.theaudiodb.com/api/v1/json/" + ApiKey;
 
         public AudioDbArtistProvider(IServerConfigurationManager config, IFileSystem fileSystem, IHttpClient httpClient, IJsonSerializer json)

--- a/MediaBrowser.Providers/Music/FanArtArtistProvider.cs
+++ b/MediaBrowser.Providers/Music/FanArtArtistProvider.cs
@@ -28,7 +28,7 @@ namespace MediaBrowser.Providers.Music
 {
     public class FanartArtistProvider : IRemoteImageProvider, IHasOrder
     {
-        internal const string ApiKey = "5c6b04c68e904cfed1e6cbc9a9e683d4";
+        internal const string ApiKey = "184e1a2b1fe3b94935365411f919f638";
         private const string FanArtBaseUrl = "https://webservice.fanart.tv/v3.1/music/{1}?api_key={0}";
 
         private readonly CultureInfo _usCulture = new CultureInfo("en-US");

--- a/MediaBrowser.Providers/Omdb/OmdbImageProvider.cs
+++ b/MediaBrowser.Providers/Omdb/OmdbImageProvider.cs
@@ -69,7 +69,7 @@ namespace MediaBrowser.Providers.Omdb
                         list.Add(new RemoteImageInfo
                         {
                             ProviderName = Name,
-                            Url = string.Format("https://img.omdbapi.com/?i={0}&apikey=fe53f97e", imdbId)
+                            Url = string.Format("https://img.omdbapi.com/?i={0}&apikey=2c9d9507", imdbId)
                         });
                     }
                 }

--- a/MediaBrowser.Providers/Omdb/OmdbProvider.cs
+++ b/MediaBrowser.Providers/Omdb/OmdbProvider.cs
@@ -270,7 +270,7 @@ namespace MediaBrowser.Providers.Omdb
 
         public static string GetOmdbUrl(string query, IApplicationHost appHost, CancellationToken cancellationToken)
         {
-            const string url = "https://www.omdbapi.com?apikey=fe53f97e";
+            const string url = "https://www.omdbapi.com?apikey=2c9d9507";
 
             if (string.IsNullOrWhiteSpace(query))
             {

--- a/MediaBrowser.Providers/TV/FanArt/FanartSeriesProvider.cs
+++ b/MediaBrowser.Providers/TV/FanArt/FanartSeriesProvider.cs
@@ -36,7 +36,6 @@ namespace MediaBrowser.Providers.TV
         private readonly IJsonSerializer _json;
 
         private const string FanArtBaseUrl = "https://webservice.fanart.tv/v3/tv/{1}?api_key={0}";
-        // &client_key=52c813aa7b8c8b3bb87f4797532a2f8c
 
         internal static FanartSeriesProvider Current { get; private set; }
 

--- a/MediaBrowser.WebDashboard/dashboard-ui/bower_components/emby-webcomponents/chromecast/chromecastplayer.js
+++ b/MediaBrowser.WebDashboard/dashboard-ui/bower_components/emby-webcomponents/chromecast/chromecastplayer.js
@@ -92,7 +92,7 @@ define(["appSettings", "userSettings", "playbackManager", "connectionManager", "
         var chrome = window.chrome;
         if (chrome) {
             if (!chrome.cast || !chrome.cast.isAvailable) return void setTimeout(this.initializeCastPlayer.bind(this), 1e3);
-            var sessionRequest = new chrome.cast.SessionRequest("2D4B1DA3"),
+            var sessionRequest = new chrome.cast.SessionRequest("F007D354"),
                 apiConfig = new chrome.cast.ApiConfig(sessionRequest, this.sessionListener.bind(this), this.receiverListener.bind(this), "origin_scoped");
             console.log("chromecast.initialize"), chrome.cast.initialize(apiConfig, this.onInitSuccess.bind(this), this.errorHandler)
         }

--- a/RSSDP/SsdpCommunicationsServer.cs
+++ b/RSSDP/SsdpCommunicationsServer.cs
@@ -129,9 +129,9 @@ namespace Rssdp.Infrastructure
                         {
                             _BroadcastListenSocket = ListenForBroadcastsAsync();
                         }
-                        catch (SocketException)
+                        catch (SocketException ex)
                         {
-                            _logger.LogError("Failed to bind to port 1900. DLNA will be unavailable");
+                            _logger.LogError("Failed to bind to port 1900: {Message}. DLNA will be unavailable", ex.Message);
                         }
                         catch (Exception ex)
                         {

--- a/RSSDP/SsdpCommunicationsServer.cs
+++ b/RSSDP/SsdpCommunicationsServer.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -129,6 +129,10 @@ namespace Rssdp.Infrastructure
                         {
                             _BroadcastListenSocket = ListenForBroadcastsAsync();
                         }
+                        catch (SocketException)
+                        {
+                            _logger.LogError("Failed to bind to port 1900. DLNA will be unavailable");
+                        }
                         catch (Exception ex)
                         {
                             _logger.LogError(ex, "Error in BeginListeningForBroadcasts");
@@ -148,7 +152,7 @@ namespace Rssdp.Infrastructure
             {
                 if (_BroadcastListenSocket != null)
                 {
-                    _logger.LogInformation("{0} disposing _BroadcastListenSocket.", GetType().Name);
+                    _logger.LogInformation("{0} disposing _BroadcastListenSocket", GetType().Name);
                     _BroadcastListenSocket.Dispose();
                     _BroadcastListenSocket = null;
                 }

--- a/SharedVersion.cs
+++ b/SharedVersion.cs
@@ -1,3 +1,3 @@
 ﻿using System.Reflection;
 
-[assembly: AssemblyVersion("10.0.1")]
+[assembly: AssemblyVersion("10.0.2")]


### PR DESCRIPTION
Hotfix release correcting regressions and obvious bugs from `10.0.1`.

Release tagged `10.0.2`. Debian build `10.0.2-1`.

This one is odd, because we want to get these hotfixes in quickly, but without the other substantial changes from dev, including the `jellyfin-web` split, which will be moved into master in `10.1.0`.

## Changelog

jellyfin/jellyfin-web#1: Change webcomponents to non-minified version [via submodule update]
jellyfin/jellyfin-web#23: Update Chromecast app ID [via submodule update]
#540: Update Emby API keys to our own
#541: Change ItemId to Guid in ProviderManager
#566: Avoid printing stacktrace when bind to port 1900 fails