### PR TITLE
Support building jellyfin-web webpack

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,50 +1,57 @@
-srpm:
-	dnf -y install git
-	git submodule update --init --recursive
-	cd deployment/fedora-package-x64;                    \
-    WORKDIR="$( pwd )"; \
-    VERSION="$( sed -ne '/^Version:/s/.*  *//p' "${WORKDIR}"/pkg-src/jellyfin.spec )"; \
-    package_temporary_dir="${WORKDIR}/pkg-dist-tmp"; \
-    pkg_src_dir="${WORKDIR}/pkg-src"; \
-    GNU_TAR=1; \
-    tar \
-    --transform "s,^\.,jellyfin-${VERSION}," \
-    --exclude='.git*' \
-    --exclude='**/.git' \
-    --exclude='**/.hg' \
-    --exclude='**/.vs' \
-    --exclude='**/.vscode' \
-    --exclude='deployment' \
-    --exclude='**/bin' \
-    --exclude='**/obj' \
-    --exclude='**/.nuget' \
-    --exclude='*.deb' \
-    --exclude='*.rpm' \
-    -czf "${SOURCE_DIR}/SOURCES/pkg-src/jellyfin-${VERSION}.tar.gz" \
-    -C ${SOURCE_DIR} ./ || GNU_TAR=0; \
-    if [ $GNU_TAR -eq 0 ]; then
-        package_temporary_dir="$( mktemp -d )"; \
-        mkdir -p "${package_temporary_dir}/jellyfin"; \
-        tar \
-        --exclude='.git*' \
-        --exclude='**/.git' \
-        --exclude='**/.hg' \
-        --exclude='**/.vs' \
-        --exclude='**/.vscode' \
-        --exclude='deployment' \
-        --exclude='**/bin' \
-        --exclude='**/obj' \
-        --exclude='**/.nuget' \
-        --exclude='*.deb' \
-        --exclude='*.rpm' \
-        -czf "${package_temporary_dir}/jellyfin/jellyfin-${VERSION}.tar.gz" \
-        -C ${SOURCE_DIR} ./; \
-        mkdir -p "${package_temporary_dir}/jellyfin-${VERSION}"; \
-        tar -xzf "${package_temporary_dir}/jellyfin/jellyfin-${VERSION}.tar.gz" -C "${package_temporary_dir}/jellyfin-${VERSION}"; \
-        rm -f "${package_temporary_dir}/jellyfin/jellyfin-${VERSION}.tar.gz"; \
-        tar -czf "${SOURCE_DIR}/SOURCES/pkg-src/jellyfin-${VERSION}.tar.gz" -C "${package_temporary_dir}" "jellyfin-${VERSION}"; \
-        rm -rf ${package_temporary_dir}; \
-    fi; \
-	rpmbuild -bs pkg-src/jellyfin.spec                   \
-	         --define "_sourcedir $$PWD/pkg-src/"        \
-		 --define "_srcrpmdir $(outdir)"
+VERSION := $(shell sed -ne '/^Version:/s/.*  *//p'                      \
+                   deployment/fedora-package-x64/pkg-src/jellyfin.spec)
+
+deployment/fedora-package-x64/pkg-src/jellyfin-web-$(VERSION).tar.gz:
+	curl -f -L -o deployment/fedora-package-x64/pkg-src/jellyfin-web-$(VERSION).tar.gz \
+         https://github.com/jellyfin/jellyfin-web/archive/v$(VERSION).tar.gz
+
+srpm: deployment/fedora-package-x64/pkg-src/jellyfin-web-$(VERSION).tar.gz
+	cd deployment/fedora-package-x64;                                             \
+    SOURCE_DIR=../..                                                              \
+    WORKDIR="$${PWD}";                                                            \
+    package_temporary_dir="$${WORKDIR}/pkg-dist-tmp";                             \
+    pkg_src_dir="$${WORKDIR}/pkg-src";                                            \
+    GNU_TAR=1;                                                                    \
+    tar                                                                           \
+    --transform "s,^\.,jellyfin-$(VERSION),"                                      \
+    --exclude='.git*'                                                             \
+    --exclude='**/.git'                                                           \
+    --exclude='**/.hg'                                                            \
+    --exclude='**/.vs'                                                            \
+    --exclude='**/.vscode'                                                        \
+    --exclude='deployment'                                                        \
+    --exclude='**/bin'                                                            \
+    --exclude='**/obj'                                                            \
+    --exclude='**/.nuget'                                                         \
+    --exclude='*.deb'                                                             \
+    --exclude='*.rpm'                                                             \
+    -czf "pkg-src/jellyfin-$(VERSION).tar.gz"                                     \
+    -C $${SOURCE_DIR} ./ || GNU_TAR=0;                                            \
+    if [ $${GNU_TAR} -eq 0 ]; then                                                \
+        package_temporary_dir="$$(mktemp -d)";                                    \
+        mkdir -p "$${package_temporary_dir}/jellyfin";                            \
+        tar                                                                       \
+        --exclude='.git*'                                                         \
+        --exclude='**/.git'                                                       \
+        --exclude='**/.hg'                                                        \
+        --exclude='**/.vs'                                                        \
+        --exclude='**/.vscode'                                                    \
+        --exclude='deployment'                                                    \
+        --exclude='**/bin'                                                        \
+        --exclude='**/obj'                                                        \
+        --exclude='**/.nuget'                                                     \
+        --exclude='*.deb'                                                         \
+        --exclude='*.rpm'                                                         \
+        -czf "$${package_temporary_dir}/jellyfin/jellyfin-$(VERSION).tar.gz"      \
+        -C $${SOURCE_DIR} ./;                                                     \
+        mkdir -p "$${package_temporary_dir}/jellyfin-$(VERSION)";                 \
+        tar -xzf "$${package_temporary_dir}/jellyfin/jellyfin-$(VERSION).tar.gz"  \
+            -C "$${package_temporary_dir}/jellyfin-$(VERSION);                    \
+        rm -f "$${package_temporary_dir}/jellyfin/jellyfin-$(VERSION).tar.gz";    \
+        tar -czf "$${SOURCE_DIR}/SOURCES/pkg-src/jellyfin-$(VERSION).tar.gz"      \
+            -C "$${package_temporary_dir}" "jellyfin-$(VERSION);                  \
+        rm -rf $${package_temporary_dir};                                         \
+	fi;                                                                           \
+	rpmbuild -bs pkg-src/jellyfin.spec                                            \
+	         --define "_sourcedir $$PWD/pkg-src/"                                 \
+	         --define "_srcrpmdir $(outdir)"

--- a/deployment/fedora-package-x64/pkg-src/jellyfin.spec
+++ b/deployment/fedora-package-x64/pkg-src/jellyfin.spec
@@ -13,20 +13,29 @@ Summary:        The Free Software Media Browser
 License:        GPLv2
 URL:            https://jellyfin.media
 Source0:        %{name}-%{version}.tar.gz
-Source1:        jellyfin.service
-Source2:        jellyfin.env
-Source3:        jellyfin.sudoers
-Source4:        restart.sh
-Source5:        jellyfin.override.conf
-Source6:        jellyfin-firewalld.xml
+Source1:        https://github.com/%{name}/%{name}-web/archive/%{name}-web-%{version}.tar.gz
+Source11:       jellyfin.service
+Source12:       jellyfin.env
+Source13:       jellyfin.sudoers
+Source14:       restart.sh
+Source15:       jellyfin.override.conf
+Source16:       jellyfin-firewalld.xml
 
 %{?systemd_requires}
 BuildRequires:  systemd
 Requires(pre):  shadow-utils
 BuildRequires:  libcurl-devel, fontconfig-devel, freetype-devel, openssl-devel, glibc-devel, libicu-devel
+%if 0%{?fedora}
+BuildRequires:  nodejs-yarn
+%else
+# Requirements not packaged in main repos
+# From https://rpm.nodesource.com/pub_8.x/el/7/x86_64/
+BuildRequires:  nodejs >= 8 yarn
+%endif
 Requires:       libcurl, fontconfig, freetype, openssl, glibc libicu
 # Requirements not packaged in main repos
-# COPR @dotnet-sig/dotnet
+# COPR @dotnet-sig/dotnet or
+# https://packages.microsoft.com/rhel/7/prod/
 BuildRequires:  dotnet-runtime-2.2, dotnet-sdk-2.2
 # RPMfusion free
 Requires:       ffmpeg
@@ -42,7 +51,18 @@ Jellyfin is a free software media system that puts you in control of managing an
 
 
 %prep
-%autosetup -n %{name}-%{version}
+%autosetup -n %{name}-%{version} -b 0 -b 1
+web_build_dir="$(mktemp -d)"
+web_target="$PWD/MediaBrowser.WebDashboard/jellyfin-web"
+pushd ../jellyfin-web-%{version}
+%if 0%{?fedora}
+nodejs-yarn install
+%else
+yarn install
+%endif
+mkdir -p ${web_target}
+mv dist/* ${web_target}/
+popd
 
 %build
 
@@ -52,7 +72,7 @@ export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 dotnet publish --configuration Release --output='%{buildroot}%{_libdir}/jellyfin' --self-contained --runtime %{dotnet_runtime} \
     "-p:GenerateDocumentationFile=false;DebugSymbols=false;DebugType=none" Jellyfin.Server
 %{__install} -D -m 0644 LICENSE %{buildroot}%{_datadir}/licenses/%{name}/LICENSE
-%{__install} -D -m 0644 %{SOURCE5} %{buildroot}%{_sysconfdir}/systemd/system/%{name}.service.d/override.conf
+%{__install} -D -m 0644 %{SOURCE15} %{buildroot}%{_sysconfdir}/systemd/system/%{name}.service.d/override.conf
 %{__install} -D -m 0644 Jellyfin.Server/Resources/Configuration/logging.json %{buildroot}%{_sysconfdir}/%{name}/logging.json
 %{__mkdir} -p %{buildroot}%{_bindir}
 tee %{buildroot}%{_bindir}/jellyfin << EOF
@@ -64,11 +84,11 @@ EOF
 %{__mkdir} -p %{buildroot}%{_var}/log/jellyfin
 %{__mkdir} -p %{buildroot}%{_var}/cache/jellyfin
 
-%{__install} -D -m 0644 %{SOURCE1} %{buildroot}%{_unitdir}/%{name}.service
-%{__install} -D -m 0644 %{SOURCE2} %{buildroot}%{_sysconfdir}/sysconfig/%{name}
-%{__install} -D -m 0600 %{SOURCE3} %{buildroot}%{_sysconfdir}/sudoers.d/%{name}-sudoers
-%{__install} -D -m 0755 %{SOURCE4} %{buildroot}%{_libexecdir}/%{name}/restart.sh
-%{__install} -D -m 0644 %{SOURCE6} %{buildroot}%{_prefix}/lib/firewalld/services/%{name}.xml
+%{__install} -D -m 0644 %{SOURCE11} %{buildroot}%{_unitdir}/%{name}.service
+%{__install} -D -m 0644 %{SOURCE12} %{buildroot}%{_sysconfdir}/sysconfig/%{name}
+%{__install} -D -m 0600 %{SOURCE13} %{buildroot}%{_sysconfdir}/sudoers.d/%{name}-sudoers
+%{__install} -D -m 0755 %{SOURCE14} %{buildroot}%{_libexecdir}/%{name}/restart.sh
+%{__install} -D -m 0644 %{SOURCE16} %{buildroot}%{_prefix}/lib/firewalld/services/%{name}.xml
 
 %files
 %{_libdir}/%{name}/jellyfin-web/*
@@ -140,6 +160,8 @@ fi
 %systemd_postun_with_restart jellyfin.service
 
 %changelog
+* Thu Oct 17 2019 Brian J. Murrell <brian@interlinx.bc.ca> 10.4.0-1
+- Build with new jellyfin-web webpack
 * Sat Aug 31 2019 Jellyfin Packaging Team <packaging@jellyfin.org>
 - New upstream version 10.4.0; release changelog at https://github.com/jellyfin/jellyfin/releases/tag/v10.4.0
 * Wed Jul 24 2019 Jellyfin Packaging Team <packaging@jellyfin.org>


### PR DESCRIPTION
Some updates to your patch to try to restore COPR build functionality.

Build-tested at https://copr.fedorainfracloud.org/coprs/brianjmurrell/jellyfin/build/1063013/

Fedora 30 package (lightly) tested locally.